### PR TITLE
Fix Guava 16 incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <httpcache4j.version>4.0-RC1</httpcache4j.version>
+    <httpcache4j.version>4.0-RC4</httpcache4j.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/codehaus/httpcache4j/spring/FilebackedStreamPayload.java
+++ b/src/main/java/org/codehaus/httpcache4j/spring/FilebackedStreamPayload.java
@@ -28,7 +28,7 @@ class FilebackedStreamPayload implements Payload {
     @Override
     public InputStream getInputStream() {
         try {
-            return fileBackedStream.getSupplier().getInput();
+            return fileBackedStream.asByteSource().openStream();
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }


### PR DESCRIPTION
httpcache4j-spring were also incompatible with Guava 16.
